### PR TITLE
update scenario's met gewijzigde toelichtingen in antwoordenmodel

### DIFF
--- a/features/S-en-T-test-omgekeerd-ouders/Tg004.feature
+++ b/features/S-en-T-test-omgekeerd-ouders/Tg004.feature
@@ -174,9 +174,9 @@ Functionaliteit: Tg004 - Custers - Bij geboorte minderjarige moeders
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_014 - minderjarig niet erkend kind, moeder ook minderjarig, geen categorie 11
     # Route: 39 - Wie heeft gezag?: geen gezag (tijdelijk) (G)

--- a/features/S-en-T-test-omgekeerd-ouders/Tg005.feature
+++ b/features/S-en-T-test-omgekeerd-ouders/Tg005.feature
@@ -452,9 +452,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000024 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_019 - gehuwd, 3 minderjarige kinderen geboren tijdens huwelijk ouders, echtgenoot en 2 kinderen geëmigreerd (RNI), 1 kind weer teruggekeerd (immigratie)
     # Meerderjarig
@@ -490,9 +490,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000061 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_022 - minderjarig kind, geboren tijdens huwelijk ouders, geen categorie 11, geëmigreerd, ingeschreven in RNI evenals vader
     # Route: 1 - Wie heeft gezag?:  (N)
@@ -529,6 +529,6 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000097 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |

--- a/features/S-en-T-test-omgekeerd-ouders/Tg026.feature
+++ b/features/S-en-T-test-omgekeerd-ouders/Tg026.feature
@@ -338,9 +338,9 @@ Functionaliteit: Tg026 - Hendriksman-Hamersma-Huisman - Erkenning voor, bij en n
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_140 - 3 kinderen in 2023, 1 erkend als ongeboren vrucht, 1 erkend bij geboorteaangifte, 1 erkend na geboorteaangifte
     # Meerderjarig

--- a/features/S-en-T-test-omgekeerd-ouders/Tg032.feature
+++ b/features/S-en-T-test-omgekeerd-ouders/Tg032.feature
@@ -130,9 +130,9 @@ Functionaliteit: Tg032 - Oostingh - Alleen maar minderjarigen incl. moeder
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_174 - minderjarige moeder, geen categorie 11
     # Route: 39 - Wie heeft gezag?: tijdelijk geen gezag (G)

--- a/features/S-en-T-test-omgekeerd-partners-kinderen/Tg004.feature
+++ b/features/S-en-T-test-omgekeerd-partners-kinderen/Tg004.feature
@@ -174,9 +174,9 @@ Functionaliteit: Tg004 - Custers - Bij geboorte minderjarige moeders
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_014 - minderjarig niet erkend kind, moeder ook minderjarig, geen categorie 11
     # Route: 39 - Wie heeft gezag?: geen gezag (tijdelijk) (G)

--- a/features/S-en-T-test-omgekeerd-partners-kinderen/Tg005.feature
+++ b/features/S-en-T-test-omgekeerd-partners-kinderen/Tg005.feature
@@ -452,9 +452,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000024 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_019 - gehuwd, 3 minderjarige kinderen geboren tijdens huwelijk ouders, echtgenoot en 2 kinderen geëmigreerd (RNI), 1 kind weer teruggekeerd (immigratie)
     # Meerderjarig
@@ -490,9 +490,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000061 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_022 - minderjarig kind, geboren tijdens huwelijk ouders, geen categorie 11, geëmigreerd, ingeschreven in RNI evenals vader
     # Route: 1 - Wie heeft gezag?:  (N)
@@ -529,6 +529,6 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000097 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |

--- a/features/S-en-T-test-omgekeerd-partners-kinderen/Tg026.feature
+++ b/features/S-en-T-test-omgekeerd-partners-kinderen/Tg026.feature
@@ -338,9 +338,9 @@ Functionaliteit: Tg026 - Hendriksman-Hamersma-Huisman - Erkenning voor, bij en n
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_140 - 3 kinderen in 2023, 1 erkend als ongeboren vrucht, 1 erkend bij geboorteaangifte, 1 erkend na geboorteaangifte
     # Meerderjarig

--- a/features/S-en-T-test-omgekeerd-partners-kinderen/Tg032.feature
+++ b/features/S-en-T-test-omgekeerd-partners-kinderen/Tg032.feature
@@ -130,9 +130,9 @@ Functionaliteit: Tg032 - Oostingh - Alleen maar minderjarigen incl. moeder
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_174 - minderjarige moeder, geen categorie 11
     # Route: 39 - Wie heeft gezag?: tijdelijk geen gezag (G)

--- a/features/S-en-T-test/Tg004.feature
+++ b/features/S-en-T-test/Tg004.feature
@@ -174,9 +174,9 @@ Functionaliteit: Tg004 - Custers - Bij geboorte minderjarige moeders
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_014 - minderjarig niet erkend kind, moeder ook minderjarig, geen categorie 11
     # Route: 39 - Wie heeft gezag?: geen gezag (tijdelijk) (G)

--- a/features/S-en-T-test/Tg005.feature
+++ b/features/S-en-T-test/Tg005.feature
@@ -452,9 +452,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000024 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_019 - gehuwd, 3 minderjarige kinderen geboren tijdens huwelijk ouders, echtgenoot en 2 kinderen geëmigreerd (RNI), 1 kind weer teruggekeerd (immigratie)
     # Meerderjarig
@@ -490,9 +490,9 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000061 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_022 - minderjarig kind, geboren tijdens huwelijk ouders, geen categorie 11, geëmigreerd, ingeschreven in RNI evenals vader
     # Route: 1 - Wie heeft gezag?:  (N)
@@ -529,6 +529,6 @@ Functionaliteit: Tg005 - Donkers-Dangor-Dass - Gezag kan niet bepaald worden
     | naam                | waarde    |
     | burgerservicenummer | 000000097 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder2 van bevraagde persoon is niet in BRP geregistreerd |

--- a/features/S-en-T-test/Tg026.feature
+++ b/features/S-en-T-test/Tg026.feature
@@ -338,9 +338,9 @@ Functionaliteit: Tg026 - Hendriksman-Hamersma-Huisman - Erkenning voor, bij en n
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_140 - 3 kinderen in 2023, 1 erkend als ongeboren vrucht, 1 erkend bij geboorteaangifte, 1 erkend na geboorteaangifte
     # Meerderjarig

--- a/features/S-en-T-test/Tg032.feature
+++ b/features/S-en-T-test/Tg032.feature
@@ -130,9 +130,9 @@ Functionaliteit: Tg032 - Oostingh - Alleen maar minderjarigen incl. moeder
     | naam                | waarde    |
     | burgerservicenummer | 000000012 |
     En heeft de persoon een 'gezag' met de volgende gegevens
-    | naam        | waarde                                                                                                                                                                                      |
-    | type        | GezagNietTeBepalen                                                                                                                                                                          |
-    | toelichting | gezag is niet te bepalen omdat bij bepaling huwelijk/partnerschap relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
+    | naam        | waarde                                                                                                                                                                                                             |
+    | type        | GezagNietTeBepalen                                                                                                                                                                                                 |
+    | toelichting | gezag is niet te bepalen omdat bij het bepalen van huwelijk/partnerschap van de ouder(s) relevante gegevens ontbreken. Het gaat om de volgende gegevens: ouder1 van bevraagde persoon is niet in BRP geregistreerd |
 
   Scenario: Lg01_174 - minderjarige moeder, geen categorie 11
     # Route: 39 - Wie heeft gezag?: tijdelijk geen gezag (G)


### PR DESCRIPTION
update is nodig, omdat sommige toelichtingen gewijzigd zijn in het antwoordenmodel 2.2.3

N.B. getest met versie 1.7.0-20241024112908. S-en-T-test en S-en-T-test-omgekeerd-ouders slagen alle scenario's.
Maar in S-en-T-test-omgekeerd-partners-kinderen falen nu 3 scenario's