### PR TITLE
feature voor persoonslijsten met opschorting F of W

### DIFF
--- a/features/specs/gezag-minderjarige/dubbele-persoonslijst.feature
+++ b/features/specs/gezag-minderjarige/dubbele-persoonslijst.feature
@@ -1,7 +1,7 @@
 # language: nl
 Functionaliteit: Leveren gezag wanneer er een persoonslijst wordt gevonden met opschorting reden F (Fout) of W (Wissen)
 
-  Regel: Wanneer de gevraagde persoonslijst opschorting F (Fout) of W (Wissen) heeft, wordt een foutmelding gegeven
+  Regel: Wanneer de gevraagde persoonslijst opschorting F (Fout) of W (Wissen) heeft, wordt geen gezag geleverd
 
     Abstract Scenario: Er is een persoonslijst met opschorting <opschorting reden>
       Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'

--- a/features/specs/gezag-minderjarige/dubbele-persoonslijst.feature
+++ b/features/specs/gezag-minderjarige/dubbele-persoonslijst.feature
@@ -1,0 +1,75 @@
+# language: nl
+Functionaliteit: Leveren gezag wanneer er een persoonslijst wordt gevonden met opschorting reden F (Fout) of W (Wissen)
+
+  Regel: Wanneer de gevraagde persoonslijst opschorting F (Fout) of W (Wissen) heeft, wordt een foutmelding gegeven
+
+    Abstract Scenario: Er is een persoonslijst met opschorting <opschorting reden>
+      Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+      * is meerderjarig
+      En de persoon 'Aart' met burgerservicenummer '000000024'
+      * is meerderjarig
+      En 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En de persoon 'Hakim' met burgerservicenummer '000000036'
+      * is meerderjarig
+      En de persoon 'Bert' met burgerservicenummer '000000048'
+      * is minderjarig
+      * is ingeschreven in de BRP
+      * is in Nederland geboren
+      * heeft 'Hakim' als ouder 1
+      En de persoonslijst van 'Bert' is opgeschort met reden '<opschorting reden>'
+      Als gezag wordt gezocht met de volgende parameters
+        | naam                | waarde    |
+        | burgerservicenummer | 000000048 |
+      Dan heeft de response een persoon met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000048 |
+      En heeft de persoon geen gezag
+
+      Voorbeelden:
+        | opschorting reden | omschrijving |
+        | F                 | Fout         |
+        | W                 | Wissen       |
+
+  Regel: Een persoonslijst met opschorting F (Fout) of W (Wissen) wordt genegeerd wanneer er ook een andere persoonslijst is met hetzelfde burgerservicenummer
+
+    Abstract Scenario: Er is een persoonslijst met opschorting <opschorting reden> en een andere persoonslijst met zelfde bsn en zonder opschorting bijhouding
+      Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+      * is meerderjarig
+      En de persoon 'Aart' met burgerservicenummer '000000024'
+      * is meerderjarig
+      En 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En de persoon 'Hakim' met burgerservicenummer '000000036'
+      * is meerderjarig
+      En de persoon 'Bert' met burgerservicenummer '000000048'
+      * is minderjarig
+      * is ingeschreven in de BRP
+      * is in Nederland geboren
+      * heeft 'Hakim' als ouder 1
+      En de persoonslijst van 'Bert' is opgeschort met reden '<opschorting reden>'
+      En de persoon 'Ernie' met burgerservicenummer '000000048'
+      * is minderjarig
+      * is ingeschreven in de BRP
+      * is in Nederland geboren
+      * heeft 'Gerda' als ouder 1
+      * heeft 'Aart' als ouder 2
+      Als gezag wordt gezocht met de volgende parameters
+        | naam                | waarde    |
+        | burgerservicenummer | 000000048 |
+      Dan heeft de response een persoon met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000048 |
+      En heeft de persoon een 'gezag' met de volgende gegevens
+        | naam                             | waarde                    |
+        | type                             | TweehoofdigOuderlijkGezag |
+        | minderjarige.burgerservicenummer |                 000000048 |
+      En heeft 'gezag' een 'ouder' met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000012 |
+      En heeft 'gezag' een 'ouder' met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000024 |
+
+      Voorbeelden:
+        | opschorting reden | omschrijving |
+        | F                 | Fout         |
+        | W                 | Wissen       |

--- a/features/step_definitions/gegeven-stepdefs-expressief.js
+++ b/features/step_definitions/gegeven-stepdefs-expressief.js
@@ -259,6 +259,18 @@ Given(/^bijhouding van de persoonsgegevens van '(.*)' is opgeschort met de volge
     );
 });
 
+Given(/^de persoonslijst van '(.*)' is opgeschort met reden '(.)'$/, function (aanduiding, redenOpschortingBijhouding) {
+    const datumOpschortingBijhouden = 'gisteren - 2 jaar';
+    
+    aanvullenInschrijving(
+        getPersoon(this.context, aanduiding),
+        arrayOfArraysToDataTable([
+            ['datum opschorting bijhouding (67.10)', datumOpschortingBijhouden],
+            ['reden opschorting bijhouding (67.20)', redenOpschortingBijhouding]
+        ])
+    );
+});
+
 Given(/^heeft de volgende gegevens$/, function (dataTable) {
     aanvullenPersoon(
         getPersoon(this.context, undefined),

--- a/src/main/java/nl/rijksoverheid/mev/brp/brpv/JooqPersoonslijstFinder.java
+++ b/src/main/java/nl/rijksoverheid/mev/brp/brpv/JooqPersoonslijstFinder.java
@@ -42,7 +42,7 @@ public class JooqPersoonslijstFinder implements PersoonslijstFinder {
 
     @Override
     public Optional<Persoonslijst> opvragenPersoonslijst(final String burgerservicenummerString) {
-        var burgerservicenummer = new Burgerservicenummer(Long.parseLong(burgerservicenummerString));
+        var burgerservicenummer = Burgerservicenummer.from(burgerservicenummerString);
 
         return findPersoonslijst(burgerservicenummer);
     }

--- a/src/main/java/nl/rijksoverheid/mev/brp/brpv/JooqPersoonslijstFinder.java
+++ b/src/main/java/nl/rijksoverheid/mev/brp/brpv/JooqPersoonslijstFinder.java
@@ -32,6 +32,9 @@ public class JooqPersoonslijstFinder implements PersoonslijstFinder {
     private static final String OUDER_2 = "2";
     private static final String KIND = "K";
     private static final String RELATIE = "R";
+    private static final String OPSCHORT_REDEN_FOUT = "F";
+    private static final String OPSCHORT_REDEN_WISSEN = "W";
+
     private final DSLContext create;
     private final LoggingContext loggingContext;
 
@@ -112,7 +115,7 @@ public class JooqPersoonslijstFinder implements PersoonslijstFinder {
                 .and(LO3_PL_PERSOON.STAPEL_NR.equal((short) 0))
                 .and(LO3_PL_PERSOON.VOLG_NR.equal((short) 0))
                 .and(LO3_PL.BIJHOUDING_OPSCHORT_REDEN.isNull()
-                    .or(LO3_PL.BIJHOUDING_OPSCHORT_REDEN.notIn("F", "W"))
+                    .or(LO3_PL.BIJHOUDING_OPSCHORT_REDEN.notIn(OPSCHORT_REDEN_FOUT, OPSCHORT_REDEN_WISSEN))
                 )
             )
             .fetchOptionalInto(Lo3PlRecord.class);

--- a/src/main/java/nl/rijksoverheid/mev/gezagsmodule/model/Burgerservicenummer.java
+++ b/src/main/java/nl/rijksoverheid/mev/gezagsmodule/model/Burgerservicenummer.java
@@ -1,6 +1,10 @@
 package nl.rijksoverheid.mev.gezagsmodule.model;
 
 public record Burgerservicenummer(long value) {
+    public static Burgerservicenummer from(String value) {
+        return new Burgerservicenummer(Long.parseLong(value));
+    }
+
     public String asString() {
         return String.valueOf(value);
     }


### PR DESCRIPTION
Fixes #306

De eerste regel geeft in geval van opschorting F of W geen gezag. Je zou er ook voor kunnen kiezen een foutmelding te geven, want de data-service mag deze vraag helemaal niet stellen. Die zal eerst hebben vastgesteld dat er alleen een persoonslijst is met opschorting F of W.
Ik heb nu gekozen dat hier leeg gezag moet worden geleverd, omdat dit ook gebeurt wanneer een burgerservicenummer is opgegeven die niet bestaat. Dat is in principe dezelfde situatie.