### PR TITLE
Gezag features

### DIFF
--- a/features/specs/README.md
+++ b/features/specs/README.md
@@ -1,0 +1,63 @@
+# Gezag
+
+## Wat is gezag?  
+Iedereen in Nederland die jonger is dan 18 jaar staat onder gezag. Dit betekent dat zij sommige beslissingen niet zelfstandig mogen nemen. Iemand die gezag heeft over een minderjarige is verantwoordelijk voor de verzorging en opvoeding van de minderjarige en beheert het geld en de spullen van de minderjarige. De gezaghouder is ook de wettelijk vertegenwoordiger van de minderjarige. Minderjarigen mogen vaak niet zelf officiële handelingen doen. De wettelijk vertegenwoordiger doet dit dan voor de minderjarige, bijvoorbeeld door een handtekening te zetten.
+De wettelijk vertegenwoordiger is ook vaak wettelijk aansprakelijk voor wat de minderjarige doet. Gezag gaat veel verder dan alleen een recht op omgang. De ouder met gezag mag namelijk belangrijke beslissingen nemen over het leven van het kind, zoals een schoolkeuze, medische beslissingen, een verhuizing, een vakantie naar het buitenland of het aanvragen van een reisdocument. Een ouder die alleen het gezag uitoefent, heeft bij het nemen van deze beslissingen geen toestemming nodig van de andere (juridische) ouder zonder gezag.
+
+Iedereen die 18 jaar of ouder is en niet onder curatele staat of een geestelijke stoornis heeft kan gezag hebben over een minderjarige. Meestal hebben de ouders het gezag. Het gezag stopt automatisch als het kind 18 jaar wordt. Een minderjarige kan niet meer dan 2 ouders hebben. Over een minderjarige kan het gezag niet door meer dan 2 personen worden uitgeoefend.
+
+### Verschillende typen gezag  
+Er zijn verschillende soorten gezag:
+- Ouderlijk gezag door één ouder (éénhoofdig ouderlijk gezag) of twee ouders (gezamenlijk ouderlijk gezag);
+- Gezamenlijk gezag van een ouder en een niet-ouder;
+- Voogdij.
+
+### Wat bedoelen we met ouders?
+Met **ouders** bedoelen we de juridische ouders volgens de wet. De juridische ouder is de ouder die op de geboorteakte staat. Hieronder staat hoe iemand juridisch ouder kan worden:
+
+De **moeder** van een kind is volgens de wet:   
+- de vrouw uit wie het kind geboren is;
+- de vrouw die het kind heeft geadopteerd; 
+- de vrouw die met de moeder is getrouwd of een geregistreerd partnerschap heeft als het kind tijdens het huwelijk of geregistreerd partnerschap geboren wordt. Om zwanger te worden is gebruik gemaakt van een onbekende zaaddonor, zoals beschreven in de Wet donorgegevens kunstmatige bevruchting; 
+- de vrouw die het kind heeft erkend;
+- de vrouw van wie het ouderschap gerechtelijk is vastgesteld.
+
+
+De **vader** van een kind is volgens de wet:   
+- de man die met de moeder is gehuwd of een geregistreerd partnerschap heeft, als het kind tijdens het huwelijk of geregistreerd partnerschap geboren wordt;
+- de man die het kind heeft erkend; 
+- de man die het kind heeft geadopteerd;
+- de man van wie het ouderschap gerechtelijk is vastgesteld. 
+
+
+Met **niet-ouder** bedoelen we:    
+- de partner van één van de ouders;
+- een derde met een nauwe persoonlijke relatie met tot de minderjarige (bijvoorbeeld een tante, oom of iemand anders);
+- een voogd.
+
+
+### Wat is voogdij?
+Voogdij is het gezag van niet-ouders. Iedereen die 18 jaar of ouder is, niet onder curatele staat en geen geestelijke stoornis heeft, kan voogd worden. Ook een jeugdzorgorganisatie (bijvoorbeeld Bureau Jeugdzorg) kan als voogd worden benoemd.
+
+Wanneer krijgt een minderjarige een voogd?
+- wanneer de ouders zijn overleden;
+- wanneer de ouders geen gezag (meer) hebben.
+
+Een minderjarige kan automatisch of via de rechter een voogd krijgen:
+- een gezaghouder met gezamenlijk gezag wordt automatisch voogd als de andere gezaghebbende ouder overlijdt of onbevoegd raakt tot de uitoefening van gezag, bijvoorbeeld omdat die ouder onder curatele staat.
+- vaak benoemt de rechter een voogd in een gerechtelijke uitspraak. Ook ouders kunnen in hun testament of door een aantekening in het gezagsregister één of twee personen als voogd aanwijzen. De voogdij begint pas als de ouders overleden zijn, het kind nog geen 18 jaar is en de voogd bij de griffie van de rechtbank verklaard heeft dat de voogdij wordt aanvaard. Als de gevraagde persoon toch geen voogd wil zijn, bepaalt de rechter wie de voogd wordt.
+
+## Leeswijzer afleidingsregels
+
+Gezag wordt bepaald door afleidingsregels in onderstaande volgorde toe te passen:
+
+1. Wanneer minderjarige de vaste verblijfplaats in het buitenland heeft, is het gezag niet te bepalen. Lees de afleidingsregels voor [gezag bepalen voor minderjarigen die in het buitenland verblijven](niet-ingezetene.feature)
+2. Er wordt vastgesteld dat geen gezag is. Lees de afleidingsregels voor [geen gezag functionaliteit](geen-gezag.feature)
+3. Er is een gerechtelijke uitspraak over gezag, die kan worden herzien door adoptie, een reparatiehuwelijk of ontkenning. Lees de afleidnigsregels voor [gerechtelijke uitspraak](gerechtelijke-uitspraak-feature)
+4. Gezag wordt bepaald van een minderjarige:
+    - met twee ouders met een relatie met elkaar. Lees de afleidingsregels voor een [minderjarige met twee ouders met relatie](twee-ouders-met-relatie.feature)
+    - met twee ouders zonder een relatie met elkaar. Lees de afleidingsregels voor een [minderjarige met twee ouders zonder relatie](twee-ouders-geen-relatie.feature)
+    - met één ouder. Lees de afleidingsregels voor een [minderjarige met één ouder](één-ouder.feature)
+    - zonder ouders. Lees de afleidingsregels voor een [minderjarige zonder ouder](geen-ouder.feature)
+5. Minderjarige heeft de de gewone verblijfplaats in het buitenland gehad. Lees de afleidingsregels voor [minderjarige die in het buitenland heeft verbleven](immigrant.feature)
+6. Gezaghouder(s) zijn niet bevoegd of overleden. Lees de afleidingsregels voor [bevoegdheid tot gezag](features/specs/gezag-minderjarige/bevoegdheid-tot-gezag.feature).

--- a/features/specs/README.md
+++ b/features/specs/README.md
@@ -53,7 +53,7 @@ Gezag wordt bepaald door afleidingsregels in onderstaande volgorde toe te passen
 
 1. Wanneer minderjarige de vaste verblijfplaats in het buitenland heeft, is het gezag niet te bepalen. Lees de afleidingsregels voor [gezag bepalen voor minderjarigen die in het buitenland verblijven](niet-ingezetene.feature)
 2. Er wordt vastgesteld dat geen gezag is. Lees de afleidingsregels voor [geen gezag functionaliteit](geen-gezag.feature)
-3. Er is een gerechtelijke uitspraak over gezag, die kan worden herzien door adoptie, een reparatiehuwelijk of ontkenning. Lees de afleidnigsregels voor [gerechtelijke uitspraak](gerechtelijke-uitspraak-feature)
+3. Er is een gerechtelijke uitspraak over gezag, die kan worden herzien door adoptie, een reparatiehuwelijk of ontkenning. Lees de afleidingsregels voor [gerechtelijke uitspraak](gerechtelijke-uitspraak-feature)
 4. Gezag wordt bepaald van een minderjarige:
     - met twee ouders met een relatie met elkaar. Lees de afleidingsregels voor een [minderjarige met twee ouders met relatie](twee-ouders-met-relatie.feature)
     - met twee ouders zonder een relatie met elkaar. Lees de afleidingsregels voor een [minderjarige met twee ouders zonder relatie](twee-ouders-geen-relatie.feature)

--- a/features/specs/bevoegdheid-tot-gezag.feature
+++ b/features/specs/bevoegdheid-tot-gezag.feature
@@ -1,0 +1,104 @@
+# language: nl
+Functionaliteit: Bevoegdheid tot gezag
+  Gezag bepalen voor een minderjarige wanneer een of beide ouders zijn overleden of niet bevoegd zijn tot gezag.
+  
+  Een persoon is onbevoegd tot gezag wanneer die:
+  - onder curatele staat
+  - minderjarig is
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Ariana' met burgerservicenummer '000000036'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000048'
+    * is minderjarig
+
+  Regel: Er is sprake van eenhoofdig ouderlijk gezag als één van de ouders met gezamenlijk ouderlijk gezag overleden of niet bevoegd is
+
+    Voorbeeld: Minderjarige heeft twee ouders en één van de ouders staat onder curatele
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Gerda' als ouder
+      * heeft 'Aart' als ouder
+      En 'Gerda' staat onder curatele
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
+
+  Regel: Er is tijdelijk geen gezag als beide ouders met gezamenlijk ouderlijk gezag overleden of niet bevoegd zijn
+    #Bespreken: een ouder of beide ouders minderjarig met meerderjarigheidsverklaring - kunnnen we meerderjarigheidsverklaring herkennen of aannemen in de BRP?
+
+    Voorbeeld: Minderjarige heeft twee ouders en beide ouders staan onder curatele
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Gerda' als ouder
+      * heeft 'Aart' als ouder
+      En 'Gerda' <bevoegdheid Gerda>
+      En 'Aart' <bevoegdheid Aart>
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting '<toelichting>.'
+
+      Voorbeelden:
+        | bevoegdheid Gerda    | bevoegdheid Aart     | toelichting                                                                                    |
+        | is overleden         | is overleden         | Tijdelijk geen gezag omdat beide ouders zijn overleden                                         |
+        | staat onder curatele | staat onder curatele | Tijdelijk geen gezag omdat beide ouders onder curatele staan                                   |
+        | is minderjarig       | is minderjarig       | Tijdelijk geen gezag omdat beide ouders minderjarig zijn                                       |
+        | is overleden         | staat onder curatele | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder onder curatele staat      |
+        | is overleden         | is minderjarig       | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder minderjarig is            |
+        | staat onder curatele | is minderjarig       | Tijdelijk geen gezag omdat een ouder onder curatele staat is en de andere ouder minderjarig is |
+
+  Regel: Er is tijdelijk geen gezag als de ouder met eenhoofdig ouderlijk gezag overleden of niet bevoegd is
+
+    Voorbeeld: Er is één ouder en die is overleden
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' als ouder
+      En 'Gerda' is overleden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat de ouder overleden is.'
+
+  Regel: De partner heeft voogdij als de ouder met gezamenlijk gezag overleden of niet bevoegd is
+
+    Voorbeeld: Minderjarige heeft ouder die gehuwd is en de ouder staat onder curatele
+      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
+      En persoon 'Bert'
+      * is geboren op 1-1-2012
+      * heeft 'Gerda' als ouder
+      En 'Gerda' staat onder curatele
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' voogdij met derde 'Ariana'
+
+  Regel: Er is sprake van voogdij als de ouder met gezamenlijk gezag met een derde overleden of niet bevoegd is
+
+    Voorbeeld: Het gezag is toegewezen aan een van de ouders met een derde en de ouder met gezag is overleden
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' als ouder
+      * heeft 'Aart' als ouder
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan ouder 'Gerda' en een derde
+      En 'Gerda' is overleden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' voogdij
+
+  Regel: Er is sprake van eenhoofdig ouderlijk gezag als de partner met gezamenlijk gezag overleden of niet bevoegd is
+
+    Voorbeeld: Minderjarige heeft ouder die gehuwd is en de partner staat onder curatele
+      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
+      En persoon 'Bert'
+      * is geboren op 1-1-2012
+      * heeft 'Gerda' als ouder
+      En 'Ariana' staat onder curatele
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  Regel: Er is tijdelijk geen gezag als de ouder en de partner met gezamenlijk gezag overleden of niet bevoegd zijn
+
+    Voorbeeld: Minderjarige heeft ouder die gehuwd is en zowel de partner als de ouder staan onder curatele
+      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
+      En persoon 'Bert'
+      * is geboren op 1-1-2012
+      * heeft 'Gerda' als ouder
+      En 'Gerda' staat onder curatele
+      En 'Ariana' staat onder curatele
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat ouder en partner onder curatele staan.'

--- a/features/specs/bevoegdheid-tot-gezag.feature
+++ b/features/specs/bevoegdheid-tot-gezag.feature
@@ -6,23 +6,10 @@ Functionaliteit: Bevoegdheid tot gezag
   - onder curatele staat
   - minderjarig is
 
-  Achtergrond:
-    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
-    * is meerderjarig
-    En de persoon 'Aart' met burgerservicenummer '000000024'
-    * is meerderjarig
-    En de persoon 'Ariana' met burgerservicenummer '000000036'
-    * is meerderjarig
-    En de persoon 'Bert' met burgerservicenummer '000000048'
-    * is minderjarig
-
   Regel: Er is sprake van eenhoofdig ouderlijk gezag als één van de ouders met gezamenlijk ouderlijk gezag overleden of niet bevoegd is
 
     Voorbeeld: Minderjarige heeft twee ouders en één van de ouders staat onder curatele
-      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
-      En persoon 'Bert'
-      * heeft 'Gerda' als ouder
-      * heeft 'Aart' als ouder
+      Gegeven de minderjarige persoon 'Bert' met twee gehuwde ouders 'Gerda' en 'Aart'
       En 'Gerda' staat onder curatele
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
@@ -31,40 +18,33 @@ Functionaliteit: Bevoegdheid tot gezag
     #Bespreken: een ouder of beide ouders minderjarig met meerderjarigheidsverklaring - kunnnen we meerderjarigheidsverklaring herkennen of aannemen in de BRP?
 
     Voorbeeld: Minderjarige heeft twee ouders en beide ouders staan onder curatele
-      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
-      En persoon 'Bert'
-      * heeft 'Gerda' als ouder
-      * heeft 'Aart' als ouder
+      Gegeven de minderjarige persoon 'Bert' met twee gehuwde ouders 'Gerda' en 'Aart'
       En 'Gerda' <bevoegdheid Gerda>
       En 'Aart' <bevoegdheid Aart>
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting '<toelichting>.'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting '<toelichting>.'
 
       Voorbeelden:
-        | bevoegdheid Gerda    | bevoegdheid Aart     | toelichting                                                                                    |
-        | is overleden         | is overleden         | Tijdelijk geen gezag omdat beide ouders zijn overleden                                         |
-        | staat onder curatele | staat onder curatele | Tijdelijk geen gezag omdat beide ouders onder curatele staan                                   |
-        | is minderjarig       | is minderjarig       | Tijdelijk geen gezag omdat beide ouders minderjarig zijn                                       |
-        | is overleden         | staat onder curatele | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder onder curatele staat      |
-        | is overleden         | is minderjarig       | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder minderjarig is            |
-        | staat onder curatele | is minderjarig       | Tijdelijk geen gezag omdat een ouder onder curatele staat is en de andere ouder minderjarig is |
+        | bevoegdheid Gerda    | bevoegdheid Aart     | toelichting                                                                                 |
+        | is overleden         | is overleden         | Tijdelijk geen gezag omdat beide ouders overleden zijn                                      |
+        | staat onder curatele | staat onder curatele | Tijdelijk geen gezag omdat beide ouders onder curatele staan                                |
+        | is minderjarig       | is minderjarig       | Tijdelijk geen gezag omdat beide ouders minderjarig zijn                                    |
+        | is overleden         | staat onder curatele | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder onder curatele staat   |
+        | is overleden         | is minderjarig       | Tijdelijk geen gezag omdat een ouder overleden is en de andere ouder minderjarig is         |
+        | staat onder curatele | is minderjarig       | Tijdelijk geen gezag omdat een ouder onder curatele staat en de andere ouder minderjarig is |
 
   Regel: Er is tijdelijk geen gezag als de ouder met eenhoofdig ouderlijk gezag overleden of niet bevoegd is
 
     Voorbeeld: Er is één ouder en die is overleden
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' als ouder
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda'
       En 'Gerda' is overleden
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat de ouder overleden is.'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting 'Tijdelijk geen gezag omdat de ouder overleden is.'
 
   Regel: De partner heeft voogdij als de ouder met gezamenlijk gezag overleden of niet bevoegd is
 
     Voorbeeld: Minderjarige heeft ouder die gehuwd is en de ouder staat onder curatele
-      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
-      En persoon 'Bert'
-      * is geboren op 1-1-2012
-      * heeft 'Gerda' als ouder
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda' die gehuwd is met 'Ariana'
       En 'Gerda' staat onder curatele
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' voogdij met derde 'Ariana'
@@ -72,10 +52,8 @@ Functionaliteit: Bevoegdheid tot gezag
   Regel: Er is sprake van voogdij als de ouder met gezamenlijk gezag met een derde overleden of niet bevoegd is
 
     Voorbeeld: Het gezag is toegewezen aan een van de ouders met een derde en de ouder met gezag is overleden
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' als ouder
-      * heeft 'Aart' als ouder
-      En in een gerechtelijke uitspraak is het gezag toegewezen aan ouder 'Gerda' en een derde
+      Gegeven de minderjarige persoon 'Bert' met twee gehuwde ouders 'Gerda' en 'Aart'
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan 'Gerda' en een derde
       En 'Gerda' is overleden
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' voogdij
@@ -83,22 +61,17 @@ Functionaliteit: Bevoegdheid tot gezag
   Regel: Er is sprake van eenhoofdig ouderlijk gezag als de partner met gezamenlijk gezag overleden of niet bevoegd is
 
     Voorbeeld: Minderjarige heeft ouder die gehuwd is en de partner staat onder curatele
-      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
-      En persoon 'Bert'
-      * is geboren op 1-1-2012
-      * heeft 'Gerda' als ouder
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda' die gehuwd is met 'Ariana'
       En 'Ariana' staat onder curatele
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
   Regel: Er is tijdelijk geen gezag als de ouder en de partner met gezamenlijk gezag overleden of niet bevoegd zijn
 
+    @to-do @skip-verify
     Voorbeeld: Minderjarige heeft ouder die gehuwd is en zowel de partner als de ouder staan onder curatele
-      Gegeven 'Gerda' en 'Ariana' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
-      En persoon 'Bert'
-      * is geboren op 1-1-2012
-      * heeft 'Gerda' als ouder
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda' die gehuwd is met 'Ariana'
       En 'Gerda' staat onder curatele
       En 'Ariana' staat onder curatele
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat ouder en partner onder curatele staan.'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting 'Tijdelijk geen gezag omdat ouder en partner onder curatele staan.'

--- a/features/specs/een-ouder.feature
+++ b/features/specs/een-ouder.feature
@@ -20,6 +20,7 @@ Functionaliteit: Eén ouder
     * is meerderjarig
     En de persoon 'Bert' met burgerservicenummer '000000048'
     * is minderjarig
+    * is ingeschreven in de BRP
     * heeft 'Gerda' als ouder
 
   Regel: Als de minderjarige niet tijdens een huwelijk of partnerschap van de juridische ouder geboren is, dan heeft de ouder eenhoofdig ouderlijk gezag
@@ -47,13 +48,13 @@ Functionaliteit: Eén ouder
       Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden gehuwd
       En 'Bert' is 6 jaar geleden geboren
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariane'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
 
     Voorbeeld: Minderjarige heeft ouder die partnerschap heeft met een meemoeder
       Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden een geregistreerd partnerschap aangegaan
       En 'Bert' is 6 jaar geleden geboren
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariane'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
 
     Voorbeeld: Minderjarige is geboren voor 1 april 2014 en moeder heeft geregistreerd partnerschap
       Gegeven 'Gerda' en 'Aart' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
@@ -71,22 +72,27 @@ Functionaliteit: Eén ouder
   Regel: Als de minderjarige tijdens het huwelijk of partnerschap van de juridische ouder is geadopteerd, dan hebben de ouder en diens (toenmalige) partner gezamenlijk gezag
     De ouder was immers bij geboorte nog geen ouder. We moeten dus kijken naar de aanvang familierechtelijke betrekking en niet naar geboortedatum
 
+    @to-do @skip-verify
     Voorbeeld: adoptieouder was niet gehuwd op geboortedatum van de minderjarige maar wel gehuwd ten tijde van de adoptiedatum
       Gegeven 'Gerda' en 'Aart' zijn 6 jaar geleden gehuwd en 2 jaar geleden gescheiden
-      En 'Bert' is 7 jaar geleden als vondeling geboren
+      En persoon 'Bert'
+      * is 7 jaar geleden als vondeling geboren
       En 'Bert' is 5 jaar geleden geadopteerd door 'Gerda'
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
 
+    @to-do @skip-verify
     Voorbeeld: adoptieouder was gehuwd op geboortedatum van de minderjarige maar niet gehuwd ten tijde van de adoptiedatum
       Gegeven 'Gerda' en 'Aart' zijn 6 jaar geleden gehuwd en 2 jaar geleden gescheiden
-      En 'Bert' is 3 jaar geleden als vondeling geboren
+      En persoon 'Bert'
+      * is 3 jaar geleden als vondeling geboren
       En 'Bert' is 1 jaar geleden geadopteerd door 'Gerda'
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
   Regel: Als de minderjarige tijdens het huwelijk of partnerschap van de juridische ouder geboren is en er sprake is van ontkenning vaderschap, dan heeft de ouder eenhoofdig ouderlijk gezag
 
+    @to-do @skip-verify
     Voorbeeld: Minderjarige heeft ouder die gehuwd is en de partner heeft het vaderschap ontkend
       Gegeven 'Gerda' en 'Aart' zijn 7 jaar geleden gehuwd
       En 'Bert' is 1 jaar geleden geboren

--- a/features/specs/een-ouder.feature
+++ b/features/specs/een-ouder.feature
@@ -1,0 +1,110 @@
+# language: nl
+Functionaliteit: Eén ouder
+  Gezag bepalen voor een minderjarige met één juridische ouder.
+  
+  Bij minderjarigen met één ouder kan er sprake zijn van gezamenlijk gezag. Gezamenlijk gezag is het gezag van een ouder en een niet ouder samen. Zij kunnen dit gezag op twee manieren krijgen: automatisch of via de rechter.
+
+  Er is automatisch sprake van gezamenlijk gezag als:
+  - Het kind is tijdens het huwelijk of geregistreerd partnerschap van de ouder geboren.
+  - Een van beide vrouwelijke partners geen ouder is geworden omdat er van een onbekende donor gebruik is gemaakt en het kind is geboren voor 1 april 2014. Als het kind is geboren op of na 1 april 2014, dan was de "meemoeder" juridisch ouder geworden.
+
+  In alle andere gevallen is gezamenlijk gezag aangevraagd bij de rechter. Als de rechter dit heeft toegekend is er sprake van gezamenlijk gezag via een gerechtelijke uitspraak. Zie 
+  [feature gerechtelijke uitspraak](gerechtelijke-uitspraak.feature)
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Ariana' met burgerservicenummer '000000036'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000048'
+    * is minderjarig
+    * heeft 'Gerda' als ouder
+
+  Regel: Als de minderjarige niet tijdens een huwelijk of partnerschap van de juridische ouder geboren is, dan heeft de ouder eenhoofdig ouderlijk gezag
+
+    Voorbeeld: De ouder is nooit gehuwd en had nooit een geregistreerd partnerschap bij geboorte
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: De ouder was gehuwd en is gescheiden voor de geboorte van minderjarige
+      Gegeven 'Gerda' en 'Aart' zijn 7 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 5 jaar geleden gescheiden
+      En 'Bert' is 2 jaar geleden geboren
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: De ouder is gehuwd na geboorte van minderjarige
+      Gegeven 'Bert' is 7 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 6 jaar geleden gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  Regel: Als de minderjarige tijdens het huwelijk of partnerschap van de juridische ouder geboren is, dan hebben de ouder en diens (toenmalige) partner gezamenlijk gezag
+
+    Voorbeeld: Minderjarige heeft ouder die gehuwd is met een meemoeder
+      Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden gehuwd
+      En 'Bert' is 6 jaar geleden geboren
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariane'
+
+    Voorbeeld: Minderjarige heeft ouder die partnerschap heeft met een meemoeder
+      Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden een geregistreerd partnerschap aangegaan
+      En 'Bert' is 6 jaar geleden geboren
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariane'
+
+    Voorbeeld: Minderjarige is geboren voor 1 april 2014 en moeder heeft geregistreerd partnerschap
+      Gegeven 'Gerda' en 'Aart' zijn een geregistreerd partnerschap aangegaan op 1-3-2010
+      En 'Bert' is geboren op 1-1-2012
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+
+    Voorbeeld: Minderjarige is geboren voor 1 april 2014 en moeder had bij geboorte geregistreerd partnerschap dat daarna is ontbonden
+      Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden een geregistreerd partnerschap aangegaan
+      En 'Bert' is 6 jaar geleden geboren
+      En het geregistreerd partnerschap van 'Gerda' en 'Ariana' is 3 jaar geleden ontbonden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
+
+  Regel: Als de minderjarige tijdens het huwelijk of partnerschap van de juridische ouder is geadopteerd, dan hebben de ouder en diens (toenmalige) partner gezamenlijk gezag
+    De ouder was immers bij geboorte nog geen ouder. We moeten dus kijken naar de aanvang familierechtelijke betrekking en niet naar geboortedatum
+
+    Voorbeeld: adoptieouder was niet gehuwd op geboortedatum van de minderjarige maar wel gehuwd ten tijde van de adoptiedatum
+      Gegeven 'Gerda' en 'Aart' zijn 6 jaar geleden gehuwd en 2 jaar geleden gescheiden
+      En 'Bert' is 7 jaar geleden als vondeling geboren
+      En 'Bert' is 5 jaar geleden geadopteerd door 'Gerda'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+
+    Voorbeeld: adoptieouder was gehuwd op geboortedatum van de minderjarige maar niet gehuwd ten tijde van de adoptiedatum
+      Gegeven 'Gerda' en 'Aart' zijn 6 jaar geleden gehuwd en 2 jaar geleden gescheiden
+      En 'Bert' is 3 jaar geleden als vondeling geboren
+      En 'Bert' is 1 jaar geleden geadopteerd door 'Gerda'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  Regel: Als de minderjarige tijdens het huwelijk of partnerschap van de juridische ouder geboren is en er sprake is van ontkenning vaderschap, dan heeft de ouder eenhoofdig ouderlijk gezag
+
+    Voorbeeld: Minderjarige heeft ouder die gehuwd is en de partner heeft het vaderschap ontkend
+      Gegeven 'Gerda' en 'Aart' zijn 7 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      En 'Aart' heeft ontkend vader te zijn van 'Bert'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  Regel: De partner behoudt gezag ook na nietigverklaring van het huwelijk
+    De nietigverklaring heeft terugwerkende kracht tot het tijdstip van de huwelijkssluiting of het aangaan van het geregistreerde partnerschap.
+    Het huwelijk of het geregistreerde partnerschap wordt geacht niet te hebben bestaan.
+    Een rechtsfeit dat heeft plaatsgevonden voor de nietigverklaring, behoudt het rechtsgevolg.
+
+    Een nietigverklaring van een huwelijk is ongelijk aan een nietig huwelijk.
+    Een nietig huwelijk of geregistreerd partnerschap heeft geen enkel rechtsgevolg.
+
+    Voorbeeld: Het huwelijk is na geboorte van de minderjarige nietig verklaard
+      Gegeven 'Gerda' en 'Ariana' zijn 7 jaar geleden gehuwd
+      En 'Bert' is 6 jaar geleden geboren
+      En het huwelijk van 'Gerda' en 'Ariana' is 5 jaar geleden nietig verklaard
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'

--- a/features/specs/geen-gezag.feature
+++ b/features/specs/geen-gezag.feature
@@ -12,12 +12,14 @@ Functionaliteit: Geen gezag
 
   Regel: Als de persoon meerderjarig is, dan is er geen sprake van gezag
 
+    @to-do @skip-verify
     Voorbeeld: De persoon is meerderjarig
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan heeft 'Bert' geen gezaghouder
 
   Regel: Als de persoon overleden is, dan is er geen sprake van gezag
 
+    @to-do @skip-verify
     Voorbeeld: De persoon is overleden
       Gegeven persoon 'Bert'
       * is overleden

--- a/features/specs/geen-gezag.feature
+++ b/features/specs/geen-gezag.feature
@@ -1,0 +1,25 @@
+# language: nl
+Functionaliteit: Geen gezag
+  Over meerderjarige of overleden personen wordt geen gezag geleverd.
+
+  Gezag over een minderjarige stopt als het kind 18 jaar wordt of is overleden. 
+
+  Achtergrond:
+    Gegeven de persoon 'Bert' met burgerservicenummer '000000036'
+    * is meerderjarig
+    * is in Nederland geboren
+    * is ingeschreven in een Nederlandse gemeente
+
+  Regel: Als de persoon meerderjarig is, dan is er geen sprake van gezag
+
+    Voorbeeld: De persoon is meerderjarig
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan heeft 'Bert' geen gezaghouder
+
+  Regel: Als de persoon overleden is, dan is er geen sprake van gezag
+
+    Voorbeeld: De persoon is overleden
+      Gegeven persoon 'Bert'
+      * is overleden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan heeft 'Bert' geen gezaghouder

--- a/features/specs/geen-ouder.feature
+++ b/features/specs/geen-ouder.feature
@@ -7,17 +7,20 @@ Functionaliteit: Geen ouder
   Achtergrond:
     Gegeven de persoon 'Bert' met burgerservicenummer '000000048'
     * is minderjarig
+    * is ingeschreven in de BRP
 
   Regel: Als er geen of alleen onbekende ouders zijn, dan is er tijdelijk geen gezag
 
+    @to-do @skip-verify
     Voorbeeld: De ouders zijn onbekend
       Gegeven persoon 'Bert'
       * is met onbekende ouders ingeschreven
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'
 
+    @to-do @skip-verify
     Voorbeeld: Er is een onbekende ouder
       Gegeven persoon 'Bert'
-      * is als vondeling ingeschreven
+      * is 1 jaar geleden als vondeling geboren
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'

--- a/features/specs/geen-ouder.feature
+++ b/features/specs/geen-ouder.feature
@@ -1,0 +1,23 @@
+# language: nl
+Functionaliteit: Geen ouder
+  Gezag bepalen voor een minderjarige zonder juridische ouder en nog geen voogdij toegewezen.
+  
+  Er kan dan een situatie ontstaan dat er geen gezag is over de minderjarige. Deze situatie is altijd tijdelijk.
+
+  Achtergrond:
+    Gegeven de persoon 'Bert' met burgerservicenummer '000000048'
+    * is minderjarig
+
+  Regel: Als er geen of alleen onbekende ouders zijn, dan is er tijdelijk geen gezag
+
+    Voorbeeld: De ouders zijn onbekend
+      Gegeven persoon 'Bert'
+      * is met onbekende ouders ingeschreven
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'
+
+    Voorbeeld: Er is een onbekende ouder
+      Gegeven persoon 'Bert'
+      * is als vondeling ingeschreven
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat beide ouders onbekend zijn'

--- a/features/specs/gerechtelijke-uitspraak.feature
+++ b/features/specs/gerechtelijke-uitspraak.feature
@@ -1,0 +1,122 @@
+# language: nl
+Functionaliteit: Gerechtelijke uitspraak
+  Voor een minderjarige waarover gerechtelijke uitspraak over gezag is gedaan, is de uitspraak alleen bepalend voor gezag als er geen ontkenning vaderschap, adoptie of (reparatie)huwelijk na de uitspraak heeft plaatsgevonden. De meest recente gebeurtenis is bepalend voor het gezag.
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000036'
+    * is minderjarig
+    En de persoon 'Ariana' met burgerservicenummer '000000048'
+    * is meerderjarig
+    En de persoon 'Gerard' met burgerservicenummer '000000061'
+    * is meerderjarig
+
+  Regel: Als er een gerechtelijke uitspraak is dat één ouder het gezag heeft, en de ouders zijn daarna (opnieuw) met elkaar gehuwd, dan is er gezamenlijk ouderlijk gezag
+    Opmerking: dit is niet altijd zo. als het gezag is beëindigd door een gezagsbeëindigende maatregel van de kinderrechter, dan herstelt het reparatiehuwelijk het gezag niet
+
+    Voorbeeld: ouders zijn opnieuw met elkaar gehuwd (reparatiehuwelijk) na de gerechtelijke uitspraak
+      Gegeven 'Gerda' en 'Aart' zijn 20 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 7 jaar geleden gescheiden
+      En persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
+      En 'Gerda' en 'Aart' zijn 2 jaar geleden opnieuw gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: ouders zijn voor het eerst met elkaar gehuwd na de gerechtelijke uitspraak
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
+      En 'Gerda' en 'Aart' zijn 2 jaar geleden gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: ouders zijn met een ander gehuwd na de gerechtelijke uitspraak
+      Gegeven 'Gerda' en 'Aart' zijn 20 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 7 jaar geleden gescheiden
+      En persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
+      En 'Gerda' en 'Gerard' zijn 2 jaar geleden opnieuw gehuwd
+      En 'Aart' en 'Ariana' zijn 1 jaar geleden opnieuw gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
+
+  Regel: Als er een gerechtelijke uitspraak is, en daarna is de minderjarige geadopteerd, dan wordt het gezag bepaald van rechtswege
+
+    Voorbeeld: na de gerechtelijke uitspraak is de minderjarige geadopteerd
+      Gegeven 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan een voogdijinstelling
+      En 'Bert' is 2 jaar geleden geadopteerd door 'Gerda' en 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: na adoptie is er gerechtelijke uitspraak over gezag
+      Gegeven 'Bert' is 6 jaar geleden geadopteerd door 'Gerda' en 'Aart'
+      En 2 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan een voogdijinstelling
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' voogdij
+
+  Regel: Als er een gerechtelijke uitspraak is dat beide ouders gezag hebben, en het ouderschap is ontkend, dan heeft de overgebleven ouder eenhoofdig ouderlijk gezag
+
+    Voorbeeld: na uitspraak over gezag aan beide ouders heeft vader ouderschap ontkend
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan beide ouders
+      En 4 jaar geleden heeft 'Aart' het ouderschap ontkend
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: na uitspraak over gezag aan vader heeft vader ouderschap ontkend
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
+      En 4 jaar geleden heeft 'Aart' het ouderschap ontkend
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat ouderschap door de gezagshouder is ontkend.'
+
+  Regel: Als er een gerechtelijke uitspraak is dat één ouder het gezag heeft, dan is er eenhoofdig ouderlijk gezag
+
+    Voorbeeld: het gezag is toegewezen aan één van de twee ouders
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
+
+  Regel: Als er een gerechtelijke uitspraak is dat beide ouders het gezag hebben, dan is er gezamenlijk ouderlijk gezag
+
+    Voorbeeld: het gezag is toegewezen aan beide ouders
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan beide ouders
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+  Regel: Als er een gerechtelijke uitspraak is dat een voogd gezag heeft, dan is er sprake is van voogdij
+
+    Voorbeeld: het gezag is toegewezen aan een voogdijinstelling
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En in een gerechtelijke uitspraak is een voogdijinstelling tot voogd benoemd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' voogdij
+
+    Voorbeeld: het gezag is toegewezen aan een derde
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En in een gerechtelijke uitspraak is een derde tot voogd benoemd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' voogdij
+
+  Regel: Als er een gerechtelijke uitspraak is dat één van de ouders gezag heeft samen met een derde, dan is er sprake van gezamenlijk gezag
+
+    Voorbeeld: het gezag is toegewezen aan een van de ouders en een derde
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' en 'Aart' als ouders
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan ouder 'Gerda' en een derde
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde

--- a/features/specs/gerechtelijke-uitspraak.feature
+++ b/features/specs/gerechtelijke-uitspraak.feature
@@ -3,86 +3,79 @@ Functionaliteit: Gerechtelijke uitspraak
   Voor een minderjarige waarover gerechtelijke uitspraak over gezag is gedaan, is de uitspraak alleen bepalend voor gezag als er geen ontkenning vaderschap, adoptie of (reparatie)huwelijk na de uitspraak heeft plaatsgevonden. De meest recente gebeurtenis is bepalend voor het gezag.
 
   Achtergrond:
-    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    Gegeven de persoon 'Ariana'
     * is meerderjarig
-    En de persoon 'Aart' met burgerservicenummer '000000024'
-    * is meerderjarig
-    En de persoon 'Bert' met burgerservicenummer '000000036'
-    * is minderjarig
-    En de persoon 'Ariana' met burgerservicenummer '000000048'
-    * is meerderjarig
-    En de persoon 'Gerard' met burgerservicenummer '000000061'
+    En de persoon 'Gerard'
     * is meerderjarig
 
   Regel: Als er een gerechtelijke uitspraak is dat één ouder het gezag heeft, en de ouders zijn daarna (opnieuw) met elkaar gehuwd, dan is er gezamenlijk ouderlijk gezag
     Opmerking: dit is niet altijd zo. als het gezag is beëindigd door een gezagsbeëindigende maatregel van de kinderrechter, dan herstelt het reparatiehuwelijk het gezag niet
 
+    @to-do @skip-verify
     Voorbeeld: ouders zijn opnieuw met elkaar gehuwd (reparatiehuwelijk) na de gerechtelijke uitspraak
-      Gegeven 'Gerda' en 'Aart' zijn 20 jaar geleden gehuwd
+      Gegeven de minderjarige persoon 'Bert' met twee gehuwde ouders 'Gerda' en 'Aart'
       En 'Gerda' en 'Aart' zijn 7 jaar geleden gescheiden
-      En persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
       En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
       En 'Gerda' en 'Aart' zijn 2 jaar geleden opnieuw gehuwd
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
 
+    @to-do @skip-verify
     Voorbeeld: ouders zijn voor het eerst met elkaar gehuwd na de gerechtelijke uitspraak
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
       En 'Gerda' en 'Aart' zijn 2 jaar geleden gehuwd
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
 
     Voorbeeld: ouders zijn met een ander gehuwd na de gerechtelijke uitspraak
-      Gegeven 'Gerda' en 'Aart' zijn 20 jaar geleden gehuwd
+      Gegeven de minderjarige persoon 'Bert' met twee gehuwde ouders 'Gerda' en 'Aart'
       En 'Gerda' en 'Aart' zijn 7 jaar geleden gescheiden
-      En persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
       En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
-      En 'Gerda' en 'Gerard' zijn 2 jaar geleden opnieuw gehuwd
-      En 'Aart' en 'Ariana' zijn 1 jaar geleden opnieuw gehuwd
+      En 'Gerda' en 'Gerard' zijn 2 jaar geleden gehuwd
+      En 'Aart' en 'Ariana' zijn 1 jaar geleden gehuwd
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
 
   Regel: Als er een gerechtelijke uitspraak is, en daarna is de minderjarige geadopteerd, dan wordt het gezag bepaald van rechtswege
 
+    @to-do @skip-verify
     Voorbeeld: na de gerechtelijke uitspraak is de minderjarige geadopteerd
-      Gegeven 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan een voogdijinstelling
-      En 'Bert' is 2 jaar geleden geadopteerd door 'Gerda' en 'Aart'
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda'
+      En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan een voogdijinstelling
+      En 'Bert' is 2 jaar geleden geadopteerd door 'Ariana' en 'Gerard'
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Ariana' en ouder 'Gerard'
 
     Voorbeeld: na adoptie is er gerechtelijke uitspraak over gezag
-      Gegeven 'Bert' is 6 jaar geleden geadopteerd door 'Gerda' en 'Aart'
+      Gegeven de minderjarige persoon 'Bert' met één ouder 'Gerda'
+      En 'Bert' is 6 jaar geleden geadopteerd door 'Ariana' en 'Gerard'
       En 2 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan een voogdijinstelling
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' voogdij
 
   Regel: Als er een gerechtelijke uitspraak is dat beide ouders gezag hebben, en het ouderschap is ontkend, dan heeft de overgebleven ouder eenhoofdig ouderlijk gezag
 
+    @to-do @skip-verify
     Voorbeeld: na uitspraak over gezag aan beide ouders heeft vader ouderschap ontkend
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan beide ouders
       En 4 jaar geleden heeft 'Aart' het ouderschap ontkend
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
+    @to-do @skip-verify
     Voorbeeld: na uitspraak over gezag aan vader heeft vader ouderschap ontkend
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En 6 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan 'Aart'
       En 4 jaar geleden heeft 'Aart' het ouderschap ontkend
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is er tijdelijk geen gezag over 'Bert' met de toelichting 'Tijdelijk geen gezag omdat ouderschap door de gezagshouder is ontkend.'
+      Dan is het gezag over 'Bert' tijdelijk geen gezag met de toelichting 'Tijdelijk geen gezag omdat ouderschap door de gezagshouder is ontkend.'
 
   Regel: Als er een gerechtelijke uitspraak is dat één ouder het gezag heeft, dan is er eenhoofdig ouderlijk gezag
 
     Voorbeeld: het gezag is toegewezen aan één van de twee ouders
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En in een gerechtelijke uitspraak is het gezag toegewezen aan 'Aart'
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Aart'
@@ -90,8 +83,7 @@ Functionaliteit: Gerechtelijke uitspraak
   Regel: Als er een gerechtelijke uitspraak is dat beide ouders het gezag hebben, dan is er gezamenlijk ouderlijk gezag
 
     Voorbeeld: het gezag is toegewezen aan beide ouders
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En in een gerechtelijke uitspraak is het gezag toegewezen aan beide ouders
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
@@ -99,15 +91,13 @@ Functionaliteit: Gerechtelijke uitspraak
   Regel: Als er een gerechtelijke uitspraak is dat een voogd gezag heeft, dan is er sprake is van voogdij
 
     Voorbeeld: het gezag is toegewezen aan een voogdijinstelling
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En in een gerechtelijke uitspraak is een voogdijinstelling tot voogd benoemd
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' voogdij
 
     Voorbeeld: het gezag is toegewezen aan een derde
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
       En in een gerechtelijke uitspraak is een derde tot voogd benoemd
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' voogdij
@@ -115,8 +105,7 @@ Functionaliteit: Gerechtelijke uitspraak
   Regel: Als er een gerechtelijke uitspraak is dat één van de ouders gezag heeft samen met een derde, dan is er sprake van gezamenlijk gezag
 
     Voorbeeld: het gezag is toegewezen aan een van de ouders en een derde
-      Gegeven persoon 'Bert'
-      * heeft 'Gerda' en 'Aart' als ouders
-      En in een gerechtelijke uitspraak is het gezag toegewezen aan ouder 'Gerda' en een derde
+      Gegeven de minderjarige persoon 'Bert' met twee ouders 'Gerda' en 'Aart' die ten tijde van de geboorte van de minderjarige niet met elkaar gehuwd waren
+      En in een gerechtelijke uitspraak is het gezag toegewezen aan 'Gerda' en een derde
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde

--- a/features/specs/immigrant.feature
+++ b/features/specs/immigrant.feature
@@ -124,6 +124,7 @@ Functionaliteit: Gezag bepalen voor personen die in het buitenland verbleven heb
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
 
+    @to-do @skip-verify
     Voorbeeld: minderjarige is geboren in het buitenland en in Nederland geadopteerd
       Gegeven persoon 'Bert'
       * is geboren op 14-10-2019

--- a/features/specs/immigrant.feature
+++ b/features/specs/immigrant.feature
@@ -1,0 +1,242 @@
+# language: nl
+Functionaliteit: Gezag bepalen voor personen die in het buitenland verbleven hebben
+  Wanneer een minderjarige een tijd een gewone verblijfplaats in het buitenland heeft gehad, kan het gezag onder de toepassing van buitenlands recht wijzigen.
+  In sommige situaties is het daardoor niet te bepalen wat het gezag is.
+
+  We hanteren hierbij de volgende principes:
+  - de gewone verblijfplaats van de minderjarige bepaalt met welk toepasselijk recht het gezag bepaald wordt. Het land waar de ouders verblijven is niet relevant
+  - eens gegeven, altijd gegeven: iemand kan niet van rechtswege het gezag verliezen door vestiging van de minderjarige in een ander land (HKV96)
+     - gezag verkregen in Nederland kan je niet verliezen door te emigreren naar een ander land
+     - gezag verkregen in een ander land kan je niet verliezen door te immigreren naar Nederland
+  - een gerechtelijke uitspraak over gezag blijft geldig na vestiging in een ander land
+  - een adoptie blijft geldig na vestiging in een ander land
+
+  Bij het bepalen van gezag wordt gekeken naar waar de persoon de "gewone" verblijfplaats heeft. Bij tijdelijk verblijf in het buitenland, bijvoorbeeld voor vakantie of een stage is de gewone verblijfplaats nog in Nederland.
+  In de API beschouwen we de gemeente van inschrijving van een persoon bepalend voor de gewone verblijfplaats. Is de persoon ingeschreven in een Nederlandse gemeente, dan heeft de persoon een Nederlands adres als gewone verblijfplaats.
+  
+
+  Nog niet uitgewerkt in deze versie:
+  - Verkrijgen van Gezamenlijk ouderlijk gezag bij ongehuwde ouders na verblijf van minderjarige in specifieke landen (België, Spanje, Polen, ...)
+  - Bepalen dat er sprake is van buitenlandse adoptie wanneer deze niet in Nederland is erkend (wanneer de buitenlandse akte nog niet is omgezet naar een Nederlandse akte bij Landelijke taken)
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000036'
+    * is minderjarig
+    En de persoon 'Zoe' met burgerservicenummer '000000048'
+    * is meerderjarig
+    En de persoon 'Giovanni' zonder burgerservicenummer
+    * is meerderjarig
+    En de persoon 'Ariana' zonder burgerservicenummer
+    * is meerderjarig
+
+  @to-do @skip-verify
+  Regel: Het gezag kan (nog) niet worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft gehad, met twee ouders en waarbij volgens de gegevens in de BRP van rechtswege eenhoofdig ouderlijk gezag zou worden bepaald
+    Het gezag is niet te bepalen omdat:
+    - We weten (nog) niet of beide ouders in het buitenland gezamenlijk ouderlijk gezag hebben gekregen. In sommige landen (België, Spanje, ...) krijgt de vader ook gezag wanneer ouders niet gehuwd zijn. De lijst met landen waar dit het geval is, is nog niet bekend.
+    - We weten niet of er sprake is van buitenlandse adoptie waardoor beide (adoptie) ouders gezag krijgen. De regels hiervoor zijn nog niet uitgewerkt.
+
+    Voorbeeld: minderjarige is geboren in het buitenland en in het buitenland geadopteerd door ongehuwde ouders en de buitenlandse adoptieakte is (nog) niet omgezet naar een Nederlandse akte
+      # Wordt nog niet door de API herkend als adoptie, later oppakken als dit grote groep blijkt te zijn
+      Gegeven persoon 'Bert'
+      * is geboren op 14-10-2019
+      * is geboren in Duitsland
+      En 'Bert' is in het buitenland geadopteerd door 'Gerda' en 'Aart' op 28-11-2019 met document 'ad akte 6029'
+      En is op 29-11-2019 geïmmigreerd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige in het buitenland heeft verbleven en onbekend is of de andere ouder dan de geboortemoeder daar gezag heeft gekregen.'
+
+    Voorbeeld: ouders van minderjarige waren nooit met elkaar gehuwd en minderjarige is erkend voor 1-1-2023 en geïmmigreerd na 1-1-2023
+      Gegeven persoon 'Bert'
+      * is geboren op 14-10-2019
+      * heeft 'Gerda' als ouder
+      En 'Bert' is erkend door 'Aart' op 30-11-2019
+      * is geboren in Duitsland
+      * is op 6-1-2023 geïmmigreerd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige in het buitenland heeft verbleven en onbekend is of de andere ouder dan de geboortemoeder daar gezag heeft gekregen.'
+
+    Voorbeeld: ouders van minderjarige waren nooit met elkaar gehuwd en minderjarige is erkend voor 1-1-2023 en is na 1-1-2023 geremigreerd naar Nederland
+      Gegeven persoon 'Bert'
+      * is geboren op 14-10-2019
+      * heeft 'Gerda' als ouder
+      En 'Bert' is erkend door 'Aart' op 30-11-2019
+      En 'Bert' is 5 jaar geleden geëmigreerd naar <land>
+      En is op 6-11-2024 geïmmigreerd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige in het buitenland heeft verbleven en onbekend is of de andere ouder dan de geboortemoeder daar gezag heeft gekregen.'
+
+      Voorbeelden:
+        | land      | omschrijving land                                                                          |
+        | Duitsland | een land waar volgens het recht van dat land geen gezamenlijk gezag ontstaat bij erkenning |
+        | Spanje    | een waar door erkenning wel gezamenlijk gezag ontstaat                                     |
+
+  @to-do @skip-verify
+  Regel: Een gerechtelijke uitspraak over het gezag voor een minderjarige blijft geldig wanneer de minderjarige een gewone verblijfplaats in het buitenland heeft gehad
+
+    Voorbeeld: minderjarige is geïmmigreerd en daarna is er in een gerechtelijke uitspraak gezag toegewezen
+      Gegeven persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      * is geboren in Duitsland
+      En is op 29-11-2022 geïmmigreerd
+      En op 27-03-2024 is in een gerechtelijke uitspraak het gezag toegewezen aan <toegewezen aan>
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' <gezag uitspraak>
+
+      Voorbeelden:
+        | toegewezen aan             | gezag uitspraak                                               |
+        | 'Aart'                     | eenhoofdig ouderlijk gezag met ouder 'Aart'                   |
+        | 'Gerda'                    | eenhoofdig ouderlijk gezag met ouder 'Gerda'                  |
+        | beide ouders               | gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart' |
+        | een voogdijinstelling      | voogdij                                                       |
+        | ouder 'Aart' en een derde  | gezamenlijk gezag met ouder 'Aart' en een onbekende derde     |
+        | ouder 'Gerda' en een derde | gezamenlijk gezag met ouder 'Gerda' en een onbekende derde    |
+
+    Voorbeeld: Er is een gerechtelijke uitspraak gezag toegewezen, daarna is de minderjarige geëmigreerd en vervolgens weer geïmmigreerd
+      Gegeven persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      En 2 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan <toegewezen aan>
+      En 'Bert' is 1 jaar geleden geëmigreerd naar België
+      En 'Bert' is vorige maand geïmmigreerd naar Nederland
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' <gezag uitspraak>
+
+      Voorbeelden:
+        | toegewezen aan             | gezag uitspraak                                               |
+        | 'Aart'                     | eenhoofdig ouderlijk gezag met ouder 'Aart'                   |
+        | 'Gerda'                    | eenhoofdig ouderlijk gezag met ouder 'Gerda'                  |
+        | beide ouders               | gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart' |
+        | een voogdijinstelling      | voogdij                                                       |
+        | ouder 'Aart' en een derde  | gezamenlijk gezag met ouder 'Aart' en een onbekende derde     |
+        | ouder 'Gerda' en een derde | gezamenlijk gezag met ouder 'Gerda' en een onbekende derde    |
+
+  Regel: Het gezag kan worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft gehad en gezamenlijk ouderlijk gezag heeft
+    @nieuw
+    Voorbeeld: minderjarige is in het buitenland geboren en heeft twee ouders die met elkaar gehuwd zijn
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      * is geboren in Duitsland
+      * is op 30-11-2022 geïmmigreerd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: minderjarige is geboren in het buitenland en in Nederland geadopteerd
+      Gegeven persoon 'Bert'
+      * is geboren op 14-10-2019
+      * is geboren in Duitsland
+      En is op 29-11-2019 geïmmigreerd
+      En 'Bert' is op 30-11-2019 geadopteerd door 'Gerda' en 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    @nieuw
+    Voorbeeld: minderjarige heeft zijn gewone verblijfplaats in het buitenland gehad en heeft twee ouders die met elkaar gehuwd zijn
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      * is geboren in Nederland
+      En 'Bert' is 10 jaar geleden geëmigreerd naar Duitsland
+      En is op 30-11-2022 geïmmigreerd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+  @to-do @skip-verify
+  Regel: Het gezag kan worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft gehad en gezamenlijk gezag heeft
+    Nederland erkent ook huwelijk van homoparen in het buitenland. Een buitenlands huwelijk heeft dus voor het bepalen van gezag dezelfde status als een huwelijk in Nederland (1:253sa BW).
+
+    Voorbeeld: minderjarige is in het buitenland geboren en heeft één ouder die ten tijde van de geboorte van minderjarige gehuwd was
+      Gegeven 'Gerda' en 'Zoe' zijn 6 jaar geleden gehuwd
+      En persoon 'Bert'
+      * heeft 'Gerda' als ouder
+      * is geboren in Duitsland
+      * is 5 jaar geleden geboren
+      * is 3 jaar geleden geïmmigreerd naar Nederland
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Zoe'
+
+  @to-do @skip-verify
+  Regel: Het gezag kan worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft gehad en één ouder heeft
+
+    Voorbeeld: minderjarige is in het buitenland geboren en heeft één ouder waarbij geen huwelijk bekend is
+      Gegeven persoon 'Bert'
+      * is geboren in Duitsland
+      * heeft 'Gerda' als ouder
+      En 'Bert' is 10 jaar geleden geïmmigreerd naar Nederland
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  @nieuw
+  Regel: het gezag kan worden bepaald voor een minderjarige waarvan een of beide gezaghebbenden niet staan ingeschreven in de BRP
+    In dat geval weten we niet met zekerheid of er iets is veranderd in de situatie van deze ouder(s). Bijvoorbeeld of een ouder uit de ouderlijke macht is ontzet of de ouder is overleden.
+    Het gezag wordt in dat geval bepaald op basis van de gegevens van de ouders zoals die bekend zijn. Daarbij wordt dan een toelichting geleverd waarin wordt aangegeven dat de persoon gewijzigd gezag kan laten opnemen in het gezagsregister.
+    De situatie dat beide ouders niet in de BRP staan heeft altijd tot gevolg dat er voogdij wordt uitgesproken.
+
+    Voorbeeld: minderjarige is in Nederland geboren en een van de ouders is niet ingeschreven in de BRP
+      Gegeven persoon 'Bert'
+      * is 1 jaar geleden geboren
+      * is ingeschreven in een Nederlandse gemeente
+      * heeft 'Gerda' als ouder
+      * heeft 'Giovanni' als ouder die niet met burgerservicenummer is ingeschreven in de BRP
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Giovanni'
+
+    @to-do @skip-verify
+    Voorbeeld: minderjarige is in Nederland geboren en een van de ouders is niet ingeschreven in de BRP
+      Gegeven persoon 'Bert'
+      * is 1 jaar geleden geboren
+      * is ingeschreven in een Nederlandse gemeente
+      * heeft 'Gerda' als ouder
+      * heeft 'Giovanni' als ouder die niet met burgerservicenummer is ingeschreven in de BRP
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Giovanni' met de toelichting 'gezag is bepaald op basis van onvolledige gegevens van Giovanni. Feiten die bepalend zijn voor het gezag van Giovanni kunnen betrokkenen in het gezagsregister dan wel bij je woongemeente laten inschrijven, zodat zij worden meegenomen in de gezagsbepaling van minderjarige.'
+
+    Voorbeeld: minderjarige is in Nederland geboren en een van de ouders is niet ingeschreven in de BRP
+      Gegeven persoon 'Bert'
+      * is 10 jaar geleden geboren
+      * is ingeschreven in een Nederlandse gemeente
+      * heeft 'Gerda' als ouder
+      * heeft 'Giovanni' als ouder die niet met burgerservicenummer is ingeschreven in de BRP
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: minderjarige is in Nederland geboren en een van de ouders is niet ingeschreven in de BRP en de ouders zijn met elkaar gehuwd
+      Gegeven persoon 'Bert'
+      * is 10 jaar geleden geboren
+      * is ingeschreven in een Nederlandse gemeente
+      * heeft 'Gerda' als ouder
+      * heeft 'Giovanni' als ouder die niet met burgerservicenummer is ingeschreven in de BRP
+      En 'Gerda' en 'Giovanni' zijn met elkaar gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Giovanni'
+
+    @to-do @skip-verify
+    Voorbeeld: minderjarige is in Nederland geboren en een van de ouders is niet ingeschreven in de BRP en de ouders zijn met elkaar gehuwd
+      Gegeven persoon 'Bert'
+      * is 10 jaar geleden geboren
+      * is ingeschreven in een Nederlandse gemeente
+      * heeft 'Gerda' als ouder
+      * heeft 'Giovanni' als ouder die niet met burgerservicenummer is ingeschreven in de BRP
+      En 'Gerda' en 'Giovanni' zijn met elkaar gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Giovanni' met de toelichting 'gezag is bepaald op basis van onvolledige gegevens van Giovanni. Feiten die bepalend zijn voor het gezag van Giovanni kunnen betrokkenen in het gezagsregister dan wel bij je woongemeente laten inschrijven, zodat zij worden meegenomen in de gezagsbepaling van minderjarige.'
+
+    Voorbeeld: minderjarige is in Nederland geboren en de ouder was op het moment van geboorte gehuwd en partner is niet ingeschreven in de BRP
+      Gegeven 'Gerda' is 12 jaar geleden gehuwd met 'Ariana' die niet met burgerservicenummer is ingeschreven in de BRP
+      En persoon 'Bert'
+      * is 10 jaar geleden geboren
+      * heeft 'Gerda' als ouder
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
+
+    @to-do @skip-verify
+    Voorbeeld: minderjarige is in Nederland geboren en de ouder was op het moment van geboorte gehuwd en partner is niet ingeschreven in de BRP
+      Gegeven 'Gerda' is 12 jaar geleden gehuwd met 'Ariana' die niet met burgerservicenummer is ingeschreven in de BRP
+      En persoon 'Bert'
+      * is 10 jaar geleden geboren
+      * heeft 'Gerda' als ouder
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana' met de toelichting 'gezag is bepaald op basis van onvolledige gegevens van Ariana Schmidt. Feiten die bepalend zijn voor het gezag van Ariana Schmidt kunnen in het gezagsregister worden opgenomen, zodat zij worden meegenomen in de gezagsbepaling van minderjarige.'

--- a/features/specs/niet-ingezetene.feature
+++ b/features/specs/niet-ingezetene.feature
@@ -1,0 +1,75 @@
+# language: nl
+Functionaliteit: Gezag bepalen voor personen die in het buitenland verblijven
+
+  Regel: Het gezag kan niet worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft
+    Dit geldt voor:
+    - een minderjarige die nooit een gewone verblijfplaats in Nederland heeft gehad
+    - een minderjarige die geëmigreerd is, omdat we niet weten wat er in het buitenland gebeurd is
+    
+    Voor niet-ingezeten personen worden gegevens over gerelateerden (ouders) en over gezagsuitspraken niet bijgehouden. 
+    Buitenlandse uitspraken over ouders en het gezag die in Nederland in het gezagsregister worden ingeschreven, worden niet in de Registratie Niet Ingezetenen (RNI) geregistreerd. 
+    Het is daarmee niet mogelijk om over alle informatie te beschikken die nodig is om het gezag te bepalen. 
+
+    Bij het bepalen van gezag wordt gekeken naar waar de persoon de "gewone" verblijfplaats heeft. Een persoon die als niet-ingezetene staat ingeschreven, maar een tijdelijke verblijfplaats in Nederland heeft, heeft op dat moment nog steeds de gewone verblijfplaats in het buitenland.
+    In de API beschouwen we de gemeente van inschrijving van een persoon bepalend voor de gewone verblijfplaats. Is de persoon ingeschreven in een Nederlandse gemeente, dan heeft de persoon een Nederlands adres als gewone verblijfplaats.
+
+    Achtergrond:
+      Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+      * is meerderjarig
+      En de persoon 'Aart' met burgerservicenummer '000000024'
+      * is meerderjarig
+      En de persoon 'Bert' met burgerservicenummer '000000036'
+      * is minderjarig
+      En de persoon 'Zoe' met burgerservicenummer '000000048'
+      * is meerderjarig
+
+    Voorbeeld: minderjarige staat ingeschreven als niet-ingezetene en heeft nooit een gewone verblijfplaats in Nederland gehad
+      Gegeven persoon 'Bert'
+      * is ingeschreven als niet-ingezetene met een verblijfplaats in België
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige niet Nederland als gewone verblijfplaats heeft.'
+
+    Voorbeeld: minderjarige is nooit ingezetene van Nederland geweest en heeft een tijdelijke verblijfplaats in Nederland
+      Gegeven persoon 'Bert'
+      * is ingeschreven als niet-ingezetene met een verblijfplaats in België
+      * is ingeschreven met een tijdelijke verblijfplaats in Nederland
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige niet Nederland als gewone verblijfplaats heeft.'
+
+    Voorbeeld: minderjarige is geëmigreerd naar het buitenland en heeft twee ouders die op het moment van emigratie met elkaar gehuwd waren
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      * is geboren in Nederland
+      En 'Bert' is 1 jaar geleden geëmigreerd naar Duitsland
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige niet Nederland als gewone verblijfplaats heeft.'
+
+    Voorbeeld: Er is in een gerechtelijke uitspraak gezag toegewezen en daarna is de minderjarige geëmigreerd
+      Gegeven persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      En 2 jaar geleden is in een gerechtelijke uitspraak het gezag toegewezen aan <toegewezen aan>
+      En 'Bert' is 1 jaar geleden geëmigreerd naar België
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige niet Nederland als gewone verblijfplaats heeft.'
+
+      Voorbeelden:
+        | toegewezen aan             | gezag uitspraak in Nederland                                  |
+        | 'Gerda'                    | eenhoofdig ouderlijk gezag met ouder 'Gerda'                  |
+        | 'Aart'                     | eenhoofdig ouderlijk gezag met ouder 'Aart'                   |
+        | beide ouders               | gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart' |
+        | een voogdijinstelling      | voogdij                                                       |
+        | ouder 'Gerda' en een derde | gezamenlijk gezag met ouder 'Gerda' en een onbekende derde    |
+        | ouder 'Aart' en een derde  | gezamenlijk gezag met ouder 'Aart' en een onbekende derde     |
+
+  Regel: Gezag als er sprake is van opschorting bijhouding ministerieel besluit
+
+    Voorbeeld: Bijhouding is opgeschort voor minderjarig kind van NAVO militair
+      Gegeven 'Gerda' en 'Aart' zijn met elkaar gehuwd
+      En persoon 'Bert'
+      * heeft 'Aart' en 'Gerda' als ouders
+      * is geboren in Nederland
+      En 'Bert' is 1 jaar geleden geëmigreerd met onbekende bestemming
+      En 1 jaar geleden is geconstateerd dat 'Aart' behoort tot de categorie NAVO-militair
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag is niet te bepalen omdat minderjarige niet Nederland als gewone verblijfplaats heeft.'

--- a/features/specs/niet-ingezetene.feature
+++ b/features/specs/niet-ingezetene.feature
@@ -1,6 +1,7 @@
 # language: nl
 Functionaliteit: Gezag bepalen voor personen die in het buitenland verblijven
 
+  @to-do @skip-verify
   Regel: Het gezag kan niet worden bepaald voor een minderjarige die een gewone verblijfplaats in het buitenland heeft
     Dit geldt voor:
     - een minderjarige die nooit een gewone verblijfplaats in Nederland heeft gehad
@@ -62,6 +63,7 @@ Functionaliteit: Gezag bepalen voor personen die in het buitenland verblijven
         | ouder 'Gerda' en een derde | gezamenlijk gezag met ouder 'Gerda' en een onbekende derde    |
         | ouder 'Aart' en een derde  | gezamenlijk gezag met ouder 'Aart' en een onbekende derde     |
 
+  @to-do @skip-verify
   Regel: Gezag als er sprake is van opschorting bijhouding ministerieel besluit
 
     Voorbeeld: Bijhouding is opgeschort voor minderjarig kind van NAVO militair

--- a/features/specs/twee-ouders-geen-relatie.feature
+++ b/features/specs/twee-ouders-geen-relatie.feature
@@ -5,12 +5,16 @@ Functionaliteit: Twee ouders geen relatie
   Achtergrond:
     Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
     * is meerderjarig
+    * is een vrouw
     En de persoon 'Aart' met burgerservicenummer '000000024'
     * is meerderjarig
-    En de persoon 'Bert' met burgerservicenummer '000000036'
-    * is minderjarig
+    * is een man
     En de persoon 'Ariana' met burgerservicenummer '000000048'
     * is meerderjarig
+    * is een vrouw
+    En de persoon 'Bert' met burgerservicenummer '000000036'
+    * is minderjarig
+    * is ingeschreven in de BRP
 
   Regel: Als de minderjarige is geadopteerd door één of beide ouders dan hebben de ouders samen gezamenlijk ouderlijk gezag
 
@@ -20,7 +24,8 @@ Functionaliteit: Twee ouders geen relatie
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
 
     Voorbeeld: Minderjarige is geadopteerd door de stiefouder
-      Gegeven 'Gerda' is ouder van 'Bert'
+      Gegeven persoon 'Bert'
+      * heeft 'Gerda' als ouder
       En 'Bert' is geadopteerd door 'Aart'
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
@@ -50,21 +55,14 @@ Functionaliteit: Twee ouders geen relatie
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
     Voorbeeld: Minderjarige is als ongeboren vrucht erkend voor 1 januari 2023
-      Gegeven persoon 'Gerda'
-      * is een vrouw
-      En persoon 'Aart'
-      * is een man
-      En 'Bert' is geboren op 30-11-2022
+      Gegeven 'Bert' is geboren op 30-11-2022
       * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
+    @to-do @skip-verify
     Voorbeeld: Ouders waren met elkaar gehuwd en zijn voor geboorte van de minderjarige gescheiden
-      Gegeven persoon 'Gerda'
-      * is een vrouw
-      En persoon 'Aart'
-      * is een man
-      En 'Gerda' en 'Aart' zijn op 1-6-2015 gehuwd
+      Gegeven 'Gerda' en 'Aart' zijn gehuwd op 1-6-2015
       En 'Gerda' en 'Aart' zijn op 1-7-2020 gescheiden
       En persoon 'Bert'
       * is geboren op 30-11-2022
@@ -73,21 +71,13 @@ Functionaliteit: Twee ouders geen relatie
       Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
 
     Voorbeeld: Minderjarige is geboren voor 1 januari 2023 en is als ongeboren vrucht erkend door andere ouder
-      Gegeven persoon 'Gerda'
-      * is een vrouw
-      En de persoon 'Ariana' met burgerservicenummer '000000024'
-      * is een vrouw
-      En 'Bert' is geboren op 30-11-2022
+      Gegeven 'Bert' is geboren op 30-11-2022
       * heeft 'Ariana' en 'Gerda' als ouders vanaf de geboortedatum
       Als 'gezag' wordt gevraagd van 'Bert'
-      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag kan niet worden bepaald omdat niet kan worden vastgesteld welke ouder de geboortemoeder is.'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'Gezag kan niet worden bepaald omdat niet kan worden vastgesteld welke ouder de geboortemoeder is.'
 
     Voorbeeld: Minderjarige is geboren voor 1 januari 2023 in een huwelijk van twee vrouwen en is als ongeboren vrucht erkend door de bekende donor
-      Gegeven persoon 'Gerda'
-      * is een vrouw
-      En persoon 'Ariana'
-      * is een vrouw
-      En 'Gerda' en 'Ariana' zijn op 1-6-2019 gehuwd
+      Gegeven 'Gerda' en 'Ariana' zijn gehuwd op 1-6-2019
       En 'Bert' is geboren op 30-11-2022
       * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
       Als 'gezag' wordt gevraagd van 'Bert'
@@ -110,6 +100,7 @@ Functionaliteit: Twee ouders geen relatie
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Ariana'
 
+  @to-do @skip-verify
   Regel: Als minderjarige na de geboorte is erkend en na 1 januari 2023 door een bekende donor, dan hebben de moeder en de partner van de moeder gezamenlijk gezag
     Vindt er vóór de geboorte géén erkenning plaats, dan heeft het kind vanaf de geboorte alleen een geboortemoeder en hebben beide moeders (geboortemoeder en haar partner) gezamenlijk het gezag (1:253sa BW). 
     De partner of de bekende donor kan daarna erkennen. Het gezag blijft bij de meemoeder en de moeder.
@@ -120,24 +111,26 @@ Functionaliteit: Twee ouders geen relatie
       Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
       En 'Bert' is 1 jaar geleden geboren
       * heeft 'Gerda' als ouder vanaf de geboortedatum
-      En 'Bert' is bij geboorteaangifte erkend door 'Aart'
+      En 'Bert' is erkend door 'Aart' bij geboorteaangifte
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en ouder 'Ariana'
 
     Voorbeeld: Minderjarige is na 1 januari 2023 en na geboorte erkend door bekende donor en moeder is gehuwd met een vrouw
-      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
-      En 'Bert' is 1 jaar geleden geboren
+      Gegeven 'Gerda' en 'Ariana' zijn gehuwd op 28-9-2022
+      En persoon 'Bert'
+      * is geboren op 4-1-2023
       * heeft 'Gerda' als ouder vanaf de geboortedatum
-      En 'Bert' is 1 maand na geboorte erkend door 'Aart'
+      En 'Bert' is erkend door 'Aart' na geboorteaangifte op 3-2-2023
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
 
   Regel: Als minderjarige na de geboorte en na 1 januari 2023 is erkend door de partner van de moeder, dan hebben de moeder en de partner van de moeder gezamenlijk ouderlijk gezag
 
     Voorbeeld: Minderjarige is na 1 januari 2023 en na de geboorte erkend door de vrouwelijke partner van de moeder (meemoeder)
-      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
-      En 'Bert' is 1 jaar geleden geboren
+      Gegeven 'Gerda' en 'Ariana' zijn gehuwd op 28-9-2022
+      En persoon 'Bert'
+      * is geboren op 4-1-2023
       * heeft 'Gerda' als ouder vanaf de geboortedatum
-      En 'Bert' is 1 maand na geboorte erkend door 'Ariana'
+      En 'Bert' is erkend door 'Ariana' na geboorteaangifte op 3-2-2023
       Als 'gezag' wordt gevraagd van 'Bert'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Ariana'

--- a/features/specs/twee-ouders-geen-relatie.feature
+++ b/features/specs/twee-ouders-geen-relatie.feature
@@ -1,0 +1,143 @@
+# language: nl
+Functionaliteit: Twee ouders geen relatie
+  Gezag bepalen voor een minderjarige met twee juridische ouders die na de geboorte van het kind niet gehuwd zijn of waren en geen partnerschap hebben of hadden.
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000036'
+    * is minderjarig
+    En de persoon 'Ariana' met burgerservicenummer '000000048'
+    * is meerderjarig
+
+  Regel: Als de minderjarige is geadopteerd door één of beide ouders dan hebben de ouders samen gezamenlijk ouderlijk gezag
+
+    Voorbeeld: Minderjarige is geadopteerd door beide ouders
+      Gegeven 'Bert' is geadopteerd door 'Gerda' en 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Minderjarige is geadopteerd door de stiefouder
+      Gegeven 'Gerda' is ouder van 'Bert'
+      En 'Bert' is geadopteerd door 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+  Regel: Als de minderjarige is erkend na 1 januari 2023 dan hebben de ouders samen gezamenlijk ouderlijk gezag
+
+    Voorbeeld: Minderjarige is als ongeboren vrucht erkend na 1 januari 2023
+      Gegeven 'Bert' is gisteren geboren
+      * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Minderjarige is erkend na 1 januari 2023
+      Gegeven 'Bert' is geboren op 29-12-2022
+      * heeft 'Gerda' als ouder vanaf de geboortedatum
+      En 'Bert' is erkend door 'Aart' op 3-1-2023
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+  Regel: Als de ouders na de geboorte van minderjarige niet met elkaar gehuwd zijn (geweest) en geen partnerschap hebben (gehad) en de minderjarige is erkend voor 1 januari 2023 dan heeft de geboortemoeder eenhoofdig ouderlijk gezag
+
+    Voorbeeld: Ouders zijn nooit met elkaar gehuwd geweest en minderjarige is erkend voor 1 januari 2023
+      Gegeven 'Bert' is geboren op 29-11-2022
+      * heeft 'Gerda' als ouder vanaf de geboortedatum
+      En 'Bert' is erkend door 'Aart' op 30-12-2022
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: Minderjarige is als ongeboren vrucht erkend voor 1 januari 2023
+      Gegeven persoon 'Gerda'
+      * is een vrouw
+      En persoon 'Aart'
+      * is een man
+      En 'Bert' is geboren op 30-11-2022
+      * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: Ouders waren met elkaar gehuwd en zijn voor geboorte van de minderjarige gescheiden
+      Gegeven persoon 'Gerda'
+      * is een vrouw
+      En persoon 'Aart'
+      * is een man
+      En 'Gerda' en 'Aart' zijn op 1-6-2015 gehuwd
+      En 'Gerda' en 'Aart' zijn op 1-7-2020 gescheiden
+      En persoon 'Bert'
+      * is geboren op 30-11-2022
+      * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+    Voorbeeld: Minderjarige is geboren voor 1 januari 2023 en is als ongeboren vrucht erkend door andere ouder
+      Gegeven persoon 'Gerda'
+      * is een vrouw
+      En de persoon 'Ariana' met burgerservicenummer '000000024'
+      * is een vrouw
+      En 'Bert' is geboren op 30-11-2022
+      * heeft 'Ariana' en 'Gerda' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'gezag kan niet worden bepaald omdat niet kan worden vastgesteld welke ouder de geboortemoeder is.'
+
+    Voorbeeld: Minderjarige is geboren voor 1 januari 2023 in een huwelijk van twee vrouwen en is als ongeboren vrucht erkend door de bekende donor
+      Gegeven persoon 'Gerda'
+      * is een vrouw
+      En persoon 'Ariana'
+      * is een vrouw
+      En 'Gerda' en 'Ariana' zijn op 1-6-2019 gehuwd
+      En 'Bert' is geboren op 30-11-2022
+      * heeft 'Aart' en 'Gerda' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+
+  Regel: Als minderjarige vóór de geboorte is erkend na 1 januari 2023, dan hebben de moeder en de erkenner gezamenlijk ouderlijk gezag
+    ⁠Als de bekende donor vóór de geboorte erkent, dan heeft de bekende donor met de geboortemoeder gezamenlijk het gezag. De echtgenote (de meemoeder) heeft dan niks: is geen ouder en heeft geen gezag. (de tenzij van 1:253sa BW)
+
+    Voorbeeld: Minderjarige is na 1 januari 2023 vóór de geboorte erkend door bekende donor en moeder is gehuwd met een vrouw
+      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      * heeft 'Gerda' en 'Aart' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Minderjarige is na 1 januari 2023 vóór de geboorte erkend door de vrouwlijke partner van de moeder (meemoeder)
+      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      * heeft 'Gerda' en 'Ariana' als ouders vanaf de geboortedatum
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Ariana'
+
+  Regel: Als minderjarige na de geboorte is erkend en na 1 januari 2023 door een bekende donor, dan hebben de moeder en de partner van de moeder gezamenlijk gezag
+    Vindt er vóór de geboorte géén erkenning plaats, dan heeft het kind vanaf de geboorte alleen een geboortemoeder en hebben beide moeders (geboortemoeder en haar partner) gezamenlijk het gezag (1:253sa BW). 
+    De partner of de bekende donor kan daarna erkennen. Het gezag blijft bij de meemoeder en de moeder.
+
+    De dag van erkenning maakt hier niet uit, kan ook de geboortedag zijn.
+
+    Voorbeeld: Minderjarige is na 1 januari 2023 en bij geboorteaangifte erkend door de bekende donor en moeder is gehuwd met een vrouw
+      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      * heeft 'Gerda' als ouder vanaf de geboortedatum
+      En 'Bert' is bij geboorteaangifte erkend door 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en ouder 'Ariana'
+
+    Voorbeeld: Minderjarige is na 1 januari 2023 en na geboorte erkend door bekende donor en moeder is gehuwd met een vrouw
+      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      * heeft 'Gerda' als ouder vanaf de geboortedatum
+      En 'Bert' is 1 maand na geboorte erkend door 'Aart'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Ariana'
+
+  Regel: Als minderjarige na de geboorte en na 1 januari 2023 is erkend door de partner van de moeder, dan hebben de moeder en de partner van de moeder gezamenlijk ouderlijk gezag
+
+    Voorbeeld: Minderjarige is na 1 januari 2023 en na de geboorte erkend door de vrouwelijke partner van de moeder (meemoeder)
+      Gegeven 'Gerda' en 'Ariana' zijn 2 jaar geleden gehuwd
+      En 'Bert' is 1 jaar geleden geboren
+      * heeft 'Gerda' als ouder vanaf de geboortedatum
+      En 'Bert' is 1 maand na geboorte erkend door 'Ariana'
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Ariana'

--- a/features/specs/twee-ouders-met-relatie.feature
+++ b/features/specs/twee-ouders-met-relatie.feature
@@ -1,0 +1,51 @@
+# language: nl
+Functionaliteit: Twee ouders met relatie
+  Gezag bepalen voor een minderjarige met twee juridische ouders die na de geboorte van het kind gehuwd zijn of waren of partnerschap hebben of hadden
+
+  Voor de situatie dat de ouders na de geboorte van minderjarige niet met elkaar gehuwd zijn (geweest) 
+  en geen partnerschap hebben (gehad), wordt het gezag bepaald volgens de [Twee ouders geen relatie functionaliteit](twee-ouders-geen-relatie.feature).
+
+  Achtergrond:
+    Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
+    * is meerderjarig
+    En de persoon 'Aart' met burgerservicenummer '000000024'
+    * is meerderjarig
+    En de persoon 'Bert' met burgerservicenummer '000000036'
+    * heeft 'Aart' en 'Gerda' als ouders
+
+  Regel: Als de ouders na de geboorte van minderjarige een periode met elkaar gehuwd zijn (geweest) of partnerschap hebben (gehad), dan hebben de ouders gezamenlijk ouderlijk gezag
+
+    Voorbeeld: Beide ouders zijn gehuwd voor geboorte van het kind en zijn dat nog steeds
+      Gegeven 'Bert' is 7 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 8 jaar geleden gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Beide ouders zijn gehuwd na geboorte van het kind en zijn dat nog steeds
+      Gegeven 'Bert' is 7 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 5 jaar geleden gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Beide ouders waren gehuwd voor geboorte van het kind en zijn na geboorte gescheiden
+      Gegeven 'Bert' is 7 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 8 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 2 jaar geleden gescheiden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Beide ouders waren gehuwd en zijn gescheiden voor geboorte van het kind en zijn na geboorte opnieuw gehuwd
+      Gegeven 'Bert' is 5 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 8 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 6 jaar geleden gescheiden
+      En 'Gerda' en 'Aart' zijn 2 jaar geleden gehuwd
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+    Voorbeeld: Beide ouders waren gehuwd na geboorte van het kind en zijn na geboorte gescheiden
+      Gegeven 'Bert' is 7 jaar geleden geboren
+      En 'Gerda' en 'Aart' zijn 5 jaar geleden gehuwd
+      En 'Gerda' en 'Aart' zijn 2 jaar geleden gescheiden
+      Als 'gezag' wordt gevraagd van 'Bert'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+ 

--- a/features/specs/twee-ouders-met-relatie.feature
+++ b/features/specs/twee-ouders-met-relatie.feature
@@ -11,6 +11,7 @@ Functionaliteit: Twee ouders met relatie
     En de persoon 'Aart' met burgerservicenummer '000000024'
     * is meerderjarig
     En de persoon 'Bert' met burgerservicenummer '000000036'
+    * is ingeschreven in de BRP
     * heeft 'Aart' en 'Gerda' als ouders
 
   Regel: Als de ouders na de geboorte van minderjarige een periode met elkaar gehuwd zijn (geweest) of partnerschap hebben (gehad), dan hebben de ouders gezamenlijk ouderlijk gezag


### PR DESCRIPTION
Gezag features die -op zo expressief mogelijke manier - beschrijven hoe gezag bepaald wordt.

Overgenomen uit #246 

Scenario's of regels die nog niet werken zoals verwacht hebben @to-do en @skip-verify gekregen.

1. features/specs/bevoegdheid-tot-gezag.feature:73 --> de API geeft nu toelichting "Tijdelijk geen gezag omdat beide ouders onder curatele staan." terwijl er een ouder en een partner is die gezag zouden hebben
2. features/specs/een-ouder.feature:76 --> Gegeven stappen werken niet goed
3. features/specs/een-ouder.feature:85 --> Gegeven stappen werken niet goed
4. features/specs/een-ouder.feature:95 --> Gegeven stappen werken niet goed
5. features/specs/een-ouder.feature --> gegeven de persoon stappen werken niet zonder bsn, dan is er geen default geboorteland ingevuld die bij opgeven van bsn wel gevuld wordt
6. features/specs/geen-gezag.feature --> `Dan heeft 'Bert' geen gezaghouder` verwacht lege array bij draaien onder gezagApi, maar moet verwachten bsn plus "gezag": []
7. features/specs/geen-ouder.feature:15 --> stap `Gegeven is met onbekende ouders ingeschreven` is niet gedefinieerd
8. features/specs/geen-ouder.feature:22 --> andere toelichting
9. features/specs/gerechtelijke-uitspraak.feature:20 --> `Gegeven 'Gerda' en 'Aart' zijn 2 jaar geleden opnieuw gehuwd` is niet gedefinieerd, zonder 'opnieuw' bestaat de stap wel --> optionele woord toevoegen aan step definition
10. features/specs/gerechtelijke-uitspraak.feature:30 --> geeft eenhoofdig ouderlijk gezag ipv gezamenlijk ouderlijk gezag. Reparatiehuwelijk anders geïmplementeerd
11. features/specs/gerechtelijke-uitspraak.feature:53 --> gezag API geeft route 0 exception
12. features/specs/gerechtelijke-uitspraak.feature:70: stap `Gegeven 4 jaar geleden heeft 'Aart' het ouderschap ontkend` werkt niet goed. Verwijderd ouderschap van 'Gerda' in plaats van 'Aart'
13. features/specs/gerechtelijke-uitspraak.feature:77: stap `Gegeven 4 jaar geleden heeft 'Aart' het ouderschap ontkend` werkt niet goed. Verwijderd ouderschap van 'Gerda' in plaats van 'Aart'
14. Op verschillende plekken stap `Gegeven in een gerechtelijke uitspraak is het gezag toegewezen aan ouder 'Gerda' en een derde` gewijzigd. Het woord 'ouder' verwijderd, omdat de stap gedefinieerd is zonder 'ouder' --> step definitie aanpassen met optioneel woord 'ouder' erin en daarna de stappen weer herstellen
15. features/specs/immigrant.feature:128 --> gezag API geeft route 0 exceptie
16. features/specs/niet-ingezetene.feature --> API geeft nu andere toelichting
17. features/specs/niet-ingezetene.feature:33 --> Gegeven is ingeschreven met een tijdelijke verblijfplaats in Nederland is niet geïmplementeerd
18. features/specs/niet-ingezetene.feature:68 --> Gegeven 'Bert' is 1 jaar geleden geëmigreerd met onbekende bestemming is niet geïmplementeerd
19. features/specs/niet-ingezetene.feature:68 --> Gegeven 1 jaar geleden is geconstateerd dat 'Aart' behoort tot de categorie NAVO-militair is niet geïmplementeerd
20. features/specs/twee-ouders-geen-relatie.feature:62 --> `Gegeven 'Gerda' en 'Aart' zijn op 1-7-2020 gescheiden` accepteert nu alleen relatieve datum en geeft dus foutmelding op vaste datum
21. features/specs/twee-ouders-geen-relatie.feature:73 --> toelichting eerste woord ('gezag') gewijzigd naar beginnend met hoofdletter. Toelichtingen in de features beginnen soms met en soms zonder hoofdletter. Implementatie nu heeft deze toelichting beginnend met hoofdletter.
22. features/specs/twee-ouders-geen-relatie.feature --> `Gegeven 'Gerda' en 'Ariana' zijn op 1-6-2019 gehuwd` gewijzigd in `Gegeven 'Gerda' en 'Ariana' zijn gehuwd op 1-6-2019` zodat het overeenkomt met huidige implementatie
23. features/specs/twee-ouders-geen-relatie.feature:109 --> `Gegeven 'Bert' is bij geboorteaangifte erkend door 'Aart'` gewijzigd naar `Gegeven 'Bert' is erkend door 'Aart' bij geboorteaangifte` zodat het overeenkomt met huidige implementatie
24. features/specs/twee-ouders-geen-relatie.feature:118 --> `Gegeven 'Bert' is 1 jaar geleden geboren En 'Bert' is 1 maand na geboorte erkend door 'Aart'` gewijzigd naar `Gegeven is geboren op 4-1-2023 En 'Bert' is erkend door 'Aart' na geboorteaangifte op 3-2-2023` omdat opgegeven stappen nog niet zijn geïmplementeerd
25. features/specs/twee-ouders-geen-relatie.feature:104 --> regel "Als minderjarige na de geboorte is erkend en na 1 januari 2023 door een bekende donor, dan hebben de moeder en de partner van de moeder gezamenlijk gezag" is nog niet geïmplementeerd in de API